### PR TITLE
Document profile update workflow

### DIFF
--- a/.github/workflows/update-profile.yml
+++ b/.github/workflows/update-profile.yml
@@ -1,0 +1,24 @@
+name: Update profile
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: python scripts/update_profile.py
+      - name: Commit changes
+        run: |
+          git config user.name 'github-actions'
+          git config user.email 'github-actions@github.com'
+          git add PROFILE.md
+          git commit -m 'Update profile' || echo 'Nothing to commit'
+      - name: Push changes
+        run: git push

--- a/README.md
+++ b/README.md
@@ -18,3 +18,14 @@ Did you enjoy this practical style of learning? There's no better way to learn t
 
 Let's keep the momentum going! Head over to [GitHub Skills](https://skills.github.com) catalog to find another hands-on exercise. :rocket:
 
+
+### Automated profile updates
+
+Run `scripts/update_profile.py` locally to refresh `PROFILE.md` using messages from `prompts.txt`:
+
+```bash
+python scripts/update_profile.py
+```
+
+A scheduled GitHub Actions workflow (`update-profile.yml`) runs this script daily. Edit `prompts.txt` to customize the messages that get posted.
+

--- a/prompts.txt
+++ b/prompts.txt
@@ -1,0 +1,3 @@
+Hello from GitHub Actions!
+Keep on coding!
+Remember to take breaks.

--- a/scripts/update_profile.py
+++ b/scripts/update_profile.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Update PROFILE.md with a random message."""
+import random
+from pathlib import Path
+from datetime import datetime
+
+ROOT = Path(__file__).resolve().parents[1]
+PROMPTS = ROOT / "prompts.txt"
+PROFILE = ROOT / "PROFILE.md"
+
+def main() -> None:
+    lines = [line.strip() for line in PROMPTS.read_text().splitlines() if line.strip()]
+    if not lines:
+        raise SystemExit("No prompts found in prompts.txt")
+    message = random.choice(lines)
+    PROFILE.write_text(f"{message}\n\nUpdated {datetime.utcnow().isoformat()} UTC\n")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python script to refresh PROFILE.md from prompts
- set up daily `update-profile` workflow
- document usage and configuration in the README

## Testing
- `python -m py_compile scripts/update_profile.py`

------
https://chatgpt.com/codex/tasks/task_e_6841d3ec8a108320a104fe972ae57cde